### PR TITLE
[FIX] Use tsx instead of ts-node for the execution of ssg example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "vite",
-    "start-ssg": "yarn build && yarn dlx -p ts-node ts-node --esm ssg/index.ts",
+    "start-ssg": "yarn build && yarn dlx -p tsx tsx ssg/index.ts",
     "build": "vite build"
   },
   "dependencies": {


### PR DESCRIPTION
I noticed an issue with ssg example #28, here is the fix